### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.21-alpine3.18
+FROM --platform=linux/amd64 golang:1.23-alpine3.19
 ADD drone-go-coverage /bin/
 RUN chmod +x /bin/drone-go-coverage
 ENTRYPOINT ["/bin/drone-go-coverage"]

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alexwilkerson/drone-go-coverage
 
-go 1.21.0
+go 1.23.0


### PR DESCRIPTION
Upgrading this, because I'm unable to run plugin on repos with version 1.22+

See: https://drone.dv.nyt.net/nytimes/nyt-groups-v2/64/2/4